### PR TITLE
Add some of the SHANGRLA nonparametric test martingales

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,0 +1,34 @@
+name: "Render Documentation"
+
+on: push
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install .[docs]
+      - name: Render Docs
+        run: |
+          cd docs
+          make html
+      - name: Upload Docs
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/_build/html/
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -7,6 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pages: write
       id-token: write
     environment:
       name: github-pages

--- a/README.md
+++ b/README.md
@@ -35,15 +35,15 @@ Then, given some observation(s) from the population we can update our test as
 follows:
 
 ```python
-exp_sprt.observe(0.5)
+exp_sprt.update(0.5)
 # <Decision.CONTINUE: 'Continue testing'>
-exp_sprt.observe(1.5)
+exp_sprt.update(1.5)
 # <Decision.CONTINUE: 'Continue testing'>
-exp_sprt.observe(1.7)
+exp_sprt.update(1.7)
 # <Decision.CONTINUE: 'Continue testing'>
-exp_sprt.observe(1.9)
+exp_sprt.update(1.9)
 # <Decision.CONTINUE: 'Continue testing'>
-exp_sprt.observe(1.0)
+exp_sprt.update(1.0)
 # <Decision.REJECT: 'Reject the null hypothesis'>
 exp_sprt.summary()
 # {'null': 'theta = 1',
@@ -74,7 +74,7 @@ norm_sprt = SPRT(
   theta1 = 2,
   loglikelihood = NormalLogLikelihood(sigma = 1)
 )
-norm_sprt.observe(np.array([1.5, 0.0, 2.4, -1.0])) # Add a batch of observations
+norm_sprt.update(np.array([1.5, 0.0, 2.4, -1.0])) # Add a batch of observations
 # <Decision.ACCEPT: 'Accept the null hypothesis'>
 norm_sprt.summary()
 # {'null': 'theta = 1',

--- a/README.md
+++ b/README.md
@@ -1,19 +1,31 @@
-# TEST Super MARTingales: `test_smart`
+# TestSmart: Sequential tests for all
 
-#### Working decription:
-The `test_smart` python package may one day contain multiple utilities for
-conducting certain sequential hypothesis tests using test (super)martingales.
-
-
-## Example: Wald's Sequential Probability Ratio Test
+A new, completely open [sequential typothesis testing](https://en.wikipedia.org/wiki/Sequential_analysis)
+library for python.
 
 
-#### SPRT: Exponential scale parameter
+## Installation
+
+Install directly from GitHub using ``pip``:
+```sh
+pip install git@github.com/fleverest/test_smart.git@main
+```
+
+Alternatively, using ``conda``:
+```sh
+conda install git@github.com/fleverest/test_smart.git@main
+```
+
+
+## Getting Started: Wald's Sequential Probability Ratio Test
+
+
+### SPRT: Exponential scale parameter
 
 Consider the simple-versus-simple hypothesis test for the scale parameter $\theta$ of
 an exponential distribution:
 
-```math
+```{math}
 H_0: \theta = 1 \text{ versus }H_1: \theta = 2.
 ```
 
@@ -53,12 +65,12 @@ exp_sprt.summary()
 #  'N': 5}
 ```
 
-#### SPRT: Normal location parameter
+### SPRT: Normal location parameter
 
 Consider the simple-versus-simple hypothesis test for the locationg parameter $\theta$
 of a normal distribution:
 
-```math
+```{math}
 H_0: \theta = 1 \text{ versus }H_1: \theta = 2.
 ```
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,39 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# Add source directory to path for autodoc.
+import sys
+import os
+
+sys.path.insert(0, os.path.abspath("../test_smart"))
+
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+project = "TestSmart"
+copyright = "2024, Floyd Everest"
+author = "Floyd Everest"
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = ["sphinx.ext.autodoc", "myst_parser"]
+
+source_suffix = {
+    ".rst": "restructuredtext",
+    ".txt": "markdown",
+    ".md": "markdown",
+}
+
+templates_path = ["_templates"]
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = "pydata_sphinx_theme"
+html_static_path = ["_static"]

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,2 @@
+```{include} ../README.md
+```

--- a/examples/alpha_estimators.py
+++ b/examples/alpha_estimators.py
@@ -1,0 +1,47 @@
+import numpy as np
+import seaborn as sns
+import polars as pl
+
+from test_smart.nnm import AlphaMart, FixedBet, AGRAPA
+
+
+n_total = 1000
+n_sample = 500
+
+x = np.random.uniform(0.1, 1, n_total)
+
+alpha_st = AlphaMart(n_total=n_total)
+alpha_fb = AlphaMart(n_total=n_total, estim=FixedBet())
+alpha_agrapa = AlphaMart(n_total=n_total, estim=AGRAPA())
+
+alpha_st.update(x[:n_sample])
+alpha_fb.update(x[:n_sample])
+alpha_agrapa.update(x[:n_sample])
+
+df = pl.DataFrame(
+    {
+        "index": np.tile(np.arange(1, n_sample + 1), 3),
+        "e-process": np.array(
+            alpha_agrapa.e_process + alpha_fb.e_process + alpha_st.e_process
+        ),
+        "p-value": np.array(
+            alpha_agrapa.p_history + alpha_fb.p_history + alpha_st.p_history
+        ),
+        "estimator": (
+            ["aGRAPA"] * n_sample
+            + ["Fixed Bet"] * n_sample
+            + ["Shrink Trunc"] * n_sample
+        ),
+    }
+)
+
+plot1 = sns.lineplot(data=df, x="index", y="e-process", hue="estimator")
+plot1.axhline(20, ls="--")
+plot1.set_yscale("log")
+plot1.get_figure().savefig("compare_estim_eproc.png")
+plot1.clear()
+
+plot2 = sns.lineplot(data=df, x="index", y="p-value", hue="estimator")
+plot2.axhline(1 / 20, ls="--")
+plot2.set_yscale("log")
+plot2.get_figure().savefig("compare_estim_pval.png")

--- a/examples/alpha_estimators.py
+++ b/examples/alpha_estimators.py
@@ -2,6 +2,8 @@ import numpy as np
 import seaborn as sns
 import polars as pl
 
+import matplotlib.pyplot as plt
+
 from test_smart.nnm import AlphaMart, FixedBet, AGRAPA, ShrinkTrunc
 
 
@@ -11,7 +13,7 @@ n_sample = 500
 x = np.random.uniform(0.1, 1, n_total)
 
 alpha_st0 = AlphaMart(n_total=n_total)
-alpha_st1 = AlphaMart(n_total=n_total, estim=ShrinkTrunc(eta0=.7))
+alpha_st1 = AlphaMart(n_total=n_total, estim=ShrinkTrunc(eta0=0.7))
 alpha_fb = AlphaMart(n_total=n_total, estim=FixedBet())
 alpha_agrapa = AlphaMart(n_total=n_total, estim=AGRAPA())
 
@@ -23,6 +25,7 @@ alpha_agrapa.update(x[:n_sample])
 df = pl.DataFrame(
     {
         "index": np.tile(np.arange(1, n_sample + 1), 4),
+        "sample mean": np.tile(alpha_st0.summaries.hist_means, 4),
         "e-process": np.array(
             alpha_agrapa.e_process
             + alpha_fb.e_process
@@ -35,6 +38,12 @@ df = pl.DataFrame(
             + alpha_st0.p_history
             + alpha_st1.p_history
         ),
+        "eta": np.array(
+            alpha_agrapa._eta_history
+            + alpha_fb._eta_history
+            + alpha_st0._eta_history
+            + alpha_st1._eta_history
+        ),
         "estimator": (
             ["aGRAPA"] * n_sample
             + ["Fixed Bet"] * n_sample
@@ -44,13 +53,20 @@ df = pl.DataFrame(
     }
 )
 
-plot1 = sns.lineplot(data=df, x="index", y="e-process", hue="estimator")
-plot1.axhline(20, ls="--")
-plot1.set_yscale("log")
-plot1.get_figure().savefig("compare_estim_eproc.png")
-plot1.clear()
+plt.figure(figsize=(10, 6))
+sns.lineplot(data=df, x="index", y="e-process", hue="estimator")
+plt.axhline(20, ls="--")
+plt.yscale("log")
+plt.savefig("compare_estim_eproc.png")
 
-plot2 = sns.lineplot(data=df, x="index", y="p-value", hue="estimator")
-plot2.axhline(1 / 20, ls="--")
-plot2.set_yscale("log")
-plot2.get_figure().savefig("compare_estim_pval.png")
+plt.figure(figsize=(10, 6))
+sns.lineplot(data=df, x="index", y="p-value", hue="estimator")
+plt.axhline(1 / 20, ls="--")
+plt.yscale("log")
+plt.savefig("compare_estim_pval.png")
+
+plt.figure(figsize=(10, 6))
+sns.lineplot(data=df, x="index", y="eta", hue="estimator")
+sns.lineplot(data=df, x="index", y="sample mean", label="sample mean")
+plt.axhline(0.5, ls="--")
+plt.savefig("compare_estim_eta.png")

--- a/examples/alpha_estimators.py
+++ b/examples/alpha_estimators.py
@@ -2,7 +2,7 @@ import numpy as np
 import seaborn as sns
 import polars as pl
 
-from test_smart.nnm import AlphaMart, FixedBet, AGRAPA
+from test_smart.nnm import AlphaMart, FixedBet, AGRAPA, ShrinkTrunc
 
 
 n_total = 1000
@@ -10,27 +10,36 @@ n_sample = 500
 
 x = np.random.uniform(0.1, 1, n_total)
 
-alpha_st = AlphaMart(n_total=n_total)
+alpha_st0 = AlphaMart(n_total=n_total)
+alpha_st1 = AlphaMart(n_total=n_total, estim=ShrinkTrunc(eta0=.7))
 alpha_fb = AlphaMart(n_total=n_total, estim=FixedBet())
 alpha_agrapa = AlphaMart(n_total=n_total, estim=AGRAPA())
 
-alpha_st.update(x[:n_sample])
+alpha_st0.update(x[:n_sample])
+alpha_st1.update(x[:n_sample])
 alpha_fb.update(x[:n_sample])
 alpha_agrapa.update(x[:n_sample])
 
 df = pl.DataFrame(
     {
-        "index": np.tile(np.arange(1, n_sample + 1), 3),
+        "index": np.tile(np.arange(1, n_sample + 1), 4),
         "e-process": np.array(
-            alpha_agrapa.e_process + alpha_fb.e_process + alpha_st.e_process
+            alpha_agrapa.e_process
+            + alpha_fb.e_process
+            + alpha_st0.e_process
+            + alpha_st1.e_process
         ),
         "p-value": np.array(
-            alpha_agrapa.p_history + alpha_fb.p_history + alpha_st.p_history
+            alpha_agrapa.p_history
+            + alpha_fb.p_history
+            + alpha_st0.p_history
+            + alpha_st1.p_history
         ),
         "estimator": (
             ["aGRAPA"] * n_sample
             + ["Fixed Bet"] * n_sample
-            + ["Shrink Trunc"] * n_sample
+            + ["Shrink Trunc default"] * n_sample
+            + ["Shrink Trunc eta0=.7"] * n_sample
         ),
     }
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,3 +47,8 @@ examples = [
     "seaborn",
     "polars"
 ]
+docs = [
+    "sphinx",
+    "pydata-sphinx-theme",
+    "myst-parser"
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,10 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]
-exclude = []
+exclude = [
+  "tests",
+  "examples"
+]
 
 [project]
 name = "test_smart"
@@ -39,4 +42,8 @@ test = [
     "flake8",
     "black",
     "flake8-black"
+]
+examples = [
+    "seaborn",
+    "polars"
 ]

--- a/test_smart/nnm.py
+++ b/test_smart/nnm.py
@@ -1,0 +1,269 @@
+import numpy as np
+
+from abc import ABC, abstractmethod
+
+from test_smart.hypothesis import SeqHypothesisTest, Decision
+from test_smart.utils import RunningSummaries, FPRunningSummaries
+
+
+def bet_to_estimate(lam: float, mu: float, u: float = 1):
+    return mu * (1 + lam * (u - mu))
+
+
+class Estimator(ABC):
+    """
+    A base class for implementing restricted estimators for the mean of a bounded,
+    non-negative random variable.
+    """
+
+    def __init__(self, n_total: int = np.inf, u: float = 1, t: float = 1 / 2):
+        self.u = u
+        self.t = t
+        self.n_total = n_total
+
+    @abstractmethod
+    def estim(self) -> float:
+        """
+        Returns an estimate of the mean for a NonnegMean test.
+        """
+        pass
+
+    def set_u_t_n(self, u: float, t: float, n_total: float) -> None:
+        self.u = u
+        self.t = t
+        self.n_total = n_total
+
+    def override_summaries(
+        self, summaries: RunningSummaries | FPRunningSummaries
+    ) -> None:
+        self.summaries = summaries
+
+
+class ShrinkTrunc(Estimator):
+
+    def __init__(
+        self,
+        u: float = 1,
+        t: float = 1 / 2,
+        n_total: int = np.inf,
+        eta0: float | None = None,
+        c: float | None = 1 / 2,
+        d: int | None = 100,
+        f: float | None = 0,
+        minsd: float | None = 1e-6,
+    ):
+        super().__init__(n_total, u, t)
+        if np.isfinite(n_total):
+            self.summaries = FPRunningSummaries(n_total, t)
+        else:
+            self.summaries = RunningSummaries()
+        self.eta0 = eta0 if eta0 else u * (1 - np.finfo(float).eps)
+        self.c = c
+        self.d = d
+        self.f = f
+        self.minsd = minsd
+
+    def estim(self) -> float:
+        """
+        Calculate a shrinkage truncation estimate for the mean of a bounded,
+        nonnegative data stream.
+        """
+        # Sum before the last data point
+        prev_sum = self.summaries.prev_sum
+        if np.isnan(prev_sum):
+            prev_sum = 0  # Zero for first samples
+        # SD before the last data point
+        prev_sd = np.sqrt(self.summaries.prev_var)
+        if np.isnan(prev_sd) or prev_sd == 0:
+            prev_sd = 1  # Replace with 1 if nan or zero, to avoid division by zero
+        # The remaining out-of-sample mean
+        m = self.summaries.oos_mean if np.isfinite(self.n_total) else self.t
+        count = self.summaries.count
+        # Shrinkage estimate, shrunk towards eta0
+        shrunk = (self.d * self.eta0 + prev_sum) / (self.d + count - 1)
+        # Reshrunk shrinkage estimate, shrunk towards u
+        reshrunked = (shrunk + self.u * self.f / prev_sd) / (1 + self.f / prev_sd)
+        # Truncated reshrunk estimate
+        return np.minimum(
+            self.u * (1 - np.finfo(float).eps),
+            np.maximum(reshrunked, m + self.c / np.sqrt(self.d + count - 1)),
+        )
+
+
+class Bet(ABC):
+    """
+    A base class for implementing bets for betting martingale tests on the mean
+    for non-negative, bounded random variables.
+    """
+
+    def __init__(self, n_total: int = np.inf, u: float = 1, t: float = 1 / 2):
+        self.u = u
+        self.t = t
+        self.n_total = n_total
+
+    @abstractmethod
+    def bet(self) -> float:
+        """
+        Returns a 'bet': a fraction of the total remaining wealth.
+        """
+        pass
+
+    def set_u_t_n(self, u: float, t: float, n_total: float) -> None:
+        self.u = u
+        self.t = t
+        self.n_total = n_total
+
+    def override_summaries(
+        self, summaries: RunningSummaries | FPRunningSummaries
+    ) -> None:
+        self.summaries = summaries
+
+
+class FixedBet(Bet):
+
+    def __init__(self, lam: float = 0.5):
+        # We don't need super().__init__(...) here, bet just returns a constant.
+        self.lam = lam
+
+    def bet(self) -> np.ndarray:
+        return self.lam
+
+
+class AGRAPA(Bet):
+
+    def __init__(
+        self,
+        u: float = 1,
+        t: float = 1 / 2,
+        n_total: int = np.inf,
+        lam0: float = 0.5,
+        c0: float = 1 - np.finfo(float).eps,
+        c_max: float = 1 - np.finfo(float).eps,
+        c_grow: float = 0,
+    ):
+        super().__init__(n_total, u, t)
+        if np.isfinite(n_total):
+            self.summaries = FPRunningSummaries(n_total, t)
+        else:
+            self.summaries = RunningSummaries()
+        self.lam0 = lam0
+        self.c0 = c0
+        self.c_max = c_max
+        self.c_grow = c_grow
+
+    def bet(self) -> np.ndarray:
+        # mean before the last data pont
+        prev_mean = self.summaries.prev_mean
+        # var before the last data point
+        prev_var = self.summaries.prev_var
+        m = self.summaries.oos_mean if np.isfinite(self.n_total) else self.t
+        lam = (prev_mean - m) / (prev_var + (prev_mean - m) ** 2)
+        if np.isnan(lam):
+            lam = self.lam0
+        c = self.c0 + (self.c_max - self.c_grow) * (
+            1 - 1 / (1 + self.c_grow * np.sqrt(self.summaries.count))
+        )
+        return np.maximum(0, np.minimum(c / m, lam))
+
+
+class NonNegMeanTest(SeqHypothesisTest):
+    """
+    A base class for implementing sequential tests for the hypothesis that a bounded,
+    non-negative random variable in [0, u] has mean less than or equal to t, where
+    0 < t < u.
+    """
+
+    def __init__(
+        self,
+        alpha: float = 0.05,
+        n_total: float = np.Inf,
+        u: float = 1,
+        t: float = 1 / 2,
+    ):
+        super().__init__(alpha, n_total)
+        self.u = u
+        self.t = t
+        if self.finite:
+            self.summaries = FPRunningSummaries(n_total, t)
+        else:
+            self.summaries = RunningSummaries()
+
+
+class AlphaMart(NonNegMeanTest):
+    """
+    The ALPHA martingale.
+    """
+
+    def __init__(
+        self,
+        alpha: float = 0.05,
+        n_total: float = np.Inf,
+        u: float = 1,
+        t: float = 1 / 2,
+        estim: Estimator | Bet | None = None,
+        atol: float = np.finfo(float).eps,
+        rtol: float = 10**-6,
+    ):
+        super().__init__(alpha, n_total, u, t)
+        if estim:
+            self.estim = estim
+        else:
+            self.estim = ShrinkTrunc(u, t, n_total)
+        self.estim.override_summaries(self.summaries)
+        self.atol = atol
+        self.rtol = rtol
+        self._eta_history = []
+        self.e_hist = []
+        self.e_process = []
+        self.p_history = []
+
+    @property
+    def pval(self) -> float:
+        return self.p_history[-1] if self.p_history else np.nan
+
+    def update(self, x: np.ndarray) -> None:
+        super().update(x)
+        x = np.array(x, ndmin=1)
+        # If multiple values are passed, just loop through them and calculate p-values
+        # one at a time.
+        for xi in x:
+            # Update summaries
+            self.summaries.add(xi)
+            # Compute out-of-sample mean
+            m = self.summaries.oos_mean if self.finite else self.t
+            # Estimate eta
+            if isinstance(self.estim, Estimator):
+                eta = self.estim.estim()  # Do not pass x to avoid updating twice
+            elif isinstance(self.estim, Bet):
+                eta = bet_to_estimate(self.estim.bet(), m, self.u)
+            self._eta_history.append(eta)
+            # compute e-value of sample xi
+            if m > self.u:
+                e_i = 0  # True mean certainly less than hypothesised
+            elif m < 0:
+                e_i = np.inf  # True mean certainly greater than hypothesised
+            elif np.isclose(0, m, atol=self.atol) or np.isclose(
+                self.u, m, atol=self.atol, rtol=self.rtol
+            ):
+                e_i = 1  # Ignore
+            else:
+                e_i = (
+                    xi * eta / m + (self.u - xi) * (self.u - eta) / (self.u - m)
+                ) / self.u
+            self.e_hist.append(e_i)
+
+            # Add to e_process (in this case it is just the cumulative product
+            # of e-values)
+            self.e_process.append(e_i * self.e_process[-1] if self.e_process else e_i)
+
+            # Compute p-value and add to history: p is the smallest 1/e seen so far
+            p = min(
+                1, self.pval if not np.isnan(self.pval) else 1, 1 / self.e_process[-1]
+            )
+            self.p_history.append(p)
+
+        if self.p_history[-1] < self.alpha:
+            self.decision = Decision.REJECT
+        else:
+            self.decision = Decision.CONTINUE
+        return self.decision

--- a/test_smart/sprt.py
+++ b/test_smart/sprt.py
@@ -83,7 +83,7 @@ class SPRT(SeqHypothesisTest):
         loglikelihood: LogLikelihood,
         **kwargs,
     ):
-        super().__init__(alpha)
+        super().__init__(alpha, n_total=np.inf)
         self.beta = beta
         self.theta0 = theta0
         self.theta1 = theta1
@@ -92,8 +92,8 @@ class SPRT(SeqHypothesisTest):
         self.S = [0]
         self.loglikelihood = loglikelihood
 
-    def observe(self, x: np.ndarray) -> Decision:
-        super().observe(x)
+    def update(self, x: np.ndarray) -> Decision:
+        super().update(x)
         self.S.extend(
             np.cumsum(
                 self.loglikelihood.ll(x, self.theta0)

--- a/tests/test_running_summaries.py
+++ b/tests/test_running_summaries.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from test_smart.utils import RunningSummaries
+from test_smart.utils import RunningSummaries, FPRunningSummaries
 
 
 class TestRunningSummaries:
@@ -21,3 +21,13 @@ class TestRunningSummaries:
         assert np.allclose(
             rs.hist_means, (np.cumsum(self.x) / np.arange(1, len(self.x) + 1))
         )
+
+    def test_final_oos_mean_is_full_mean(self):
+        rs = FPRunningSummaries(pop_size=len(self.x), pop_mean=np.mean(self.x))
+        rs.add(self.x[:-1])
+        assert np.isclose(self.x[-1], rs.oos_mean)
+
+    def test_final_oos_count_is_zero(self):
+        rs = FPRunningSummaries(pop_size=len(self.x), pop_mean=np.mean(self.x))
+        rs.add(self.x)
+        assert rs.oos_count == 0

--- a/tests/test_running_summaries.py
+++ b/tests/test_running_summaries.py
@@ -5,7 +5,7 @@ from test_smart.utils import RunningSummaries, FPRunningSummaries
 
 class TestRunningSummaries:
     """
-    Tests for the various summaries for updated
+    Tests for RunningSummaries and FPRunningSummaries.
     """
 
     x = np.array([1.5, 2.5, 1.7, 1.0, 1.2, 2.1, 1.4, 1.8])


### PR DESCRIPTION
- Adds similar functionality to the `shangrla.core.NonnegMean.NonnegMean` tests
- Currently only supports ALPHA with Shrink-trunc estimates, aGRAPA bets, or fixed bets.